### PR TITLE
Weapon Cycle Switching (Cycle Weapon)

### DIFF
--- a/Assets/Input/MainPlayerInput.inputactions
+++ b/Assets/Input/MainPlayerInput.inputactions
@@ -40,6 +40,42 @@
                     "processors": "",
                     "interactions": "Press(behavior=2)",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "PSwitchEquipment",
+                    "type": "Button",
+                    "id": "21d35e8d-bdcc-4283-ab05-fdd2b77567b3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "PWeapon1",
+                    "type": "Button",
+                    "id": "ef04b7f1-12dd-4c21-83ef-083dbb9d15a3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "PWeapon2",
+                    "type": "Button",
+                    "id": "8233ae9d-5837-449f-8edd-3258c6b9f26d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "PWeapon3",
+                    "type": "Button",
+                    "id": "cb9326e2-e232-4165-8fa2-b4dfa5268838",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
                 }
             ],
             "bindings": [
@@ -293,6 +329,61 @@
                     "processors": "",
                     "groups": "Gamepad",
                     "action": "PReload",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f11fd4c8-7c56-4317-ba35-1825beed56d0",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PSwitchEquipment",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3b9f52f4-d89f-4187-9425-8857bb49688e",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "PSwitchEquipment",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ef708326-79f6-41a2-ae0d-1dccb90097e1",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PWeapon1",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4d204ac5-c5db-4db2-897b-c29271a301ef",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PWeapon2",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0ead52be-55b1-4f2c-b979-c6d691cc736d",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PWeapon3",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Prefabs/Weapons/_PLACEHOLDER/Weapon Knife Swing.prefab
+++ b/Assets/Prefabs/Weapons/_PLACEHOLDER/Weapon Knife Swing.prefab
@@ -327,7 +327,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parentHolder: {fileID: 0}
   parentAttach: {fileID: 0}
-  startingAmmo: 5
+  startingAmmo: Infinity
   weaponInputScript: {fileID: 2841505596119360413}
   weaponSpriteScript: {fileID: 2841505596119360402}
   weaponAnimationScript: {fileID: 2841505596119360414}

--- a/Assets/Prefabs/Weapons/_PLACEHOLDER/Weapon Knife.prefab
+++ b/Assets/Prefabs/Weapons/_PLACEHOLDER/Weapon Knife.prefab
@@ -327,7 +327,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parentHolder: {fileID: 0}
   parentAttach: {fileID: 0}
-  startingAmmo: 5
+  startingAmmo: Infinity
   weaponInputScript: {fileID: 2841505596119360413}
   weaponSpriteScript: {fileID: 2841505596119360402}
   weaponAnimationScript: {fileID: 2841505596119360414}

--- a/Assets/Scripts/Core/InventoryScript.cs
+++ b/Assets/Scripts/Core/InventoryScript.cs
@@ -3,19 +3,41 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.Events;
 
 public class InventoryScript : MonoBehaviour
 {
+    // Events
+    [Header("Events")]
+    internal UnityEvent OnEquipmentSwitch = new UnityEvent();
+
     // Components
     [Header("Components")]
     [SerializeField]
     private GameObject inventoryHolder;
 
     // Variables
-    private List<IEquipmentItem> equipments;
+    internal List<IEquipmentItem> equipments;
 
     [SerializeField]
-    internal IEquipmentItem currentEquippedItem;
+    internal int equippedItemIndex;
+
+    #region INPUTS
+    // OnPSwitchEquipment listener from InputAction "MainPlayerInput.inputaction"
+    void OnPSwitchEquipment()
+    {
+        // Determine the next weapon index to cycle
+        // If equipped index is the last equipment in inventory, go back to 0
+        // Otherwise, add 1 to equipped index item (cycle to the next weapon)
+        int nextWeaponIndex = equippedItemIndex >= equipments.Count - 1 ? 0 : equippedItemIndex + 1;
+
+        // Switch equipment
+        SwitchEquipment(nextWeaponIndex);
+
+        OnEquipmentSwitch.Invoke();
+    }
+    #endregion
 
     // Awake is called when the script instance is being loaded
     private void Awake()
@@ -32,13 +54,22 @@ public class InventoryScript : MonoBehaviour
         equipments = inventoryHolder.GetComponentsInChildren<IEquipmentItem>(true).ToList();
     }
 
+    internal IEquipmentItem GetCurrentEquippedItem()
+    {
+        return GetCurrentEquippedItem(equippedItemIndex);
+    }
+    internal IEquipmentItem GetCurrentEquippedItem(int index)
+    {
+        return equipments[index];
+    }
+
     // TODO: (DUPLICATE) Finish implementing weapon switching and HUD weapon script assigning.
     internal void SwitchEquipment(int index)
     {
         // Use try catch to prevent index out of bounds exception
         try
         {
-            GameObject obj = new GameObject();
+            GameObject obj = null;
 
             // Go through equipments list
             for (int i = 0; i < equipments.Count; i++)
@@ -49,7 +80,7 @@ public class InventoryScript : MonoBehaviour
                 // Activate selected equipment
                 if (i == index)
                 {
-                    currentEquippedItem = equipments[index];
+                    equippedItemIndex = index;
                     obj.SetActive(true);
                 }
 

--- a/Assets/Scripts/UI/Screen HUD/HUDAmmoScript.cs
+++ b/Assets/Scripts/UI/Screen HUD/HUDAmmoScript.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -19,22 +19,38 @@ public class HUDAmmoScript : MonoBehaviour
     [SerializeField]
     private WeaponScript playerWeaponScript;
 
+    // Variables
+    private PlayerScript activePlayer;
+
     // Start is called before the first frame update
     void Start()
     {
         Debug.Log("HUDAmmoScript starting");
+
+        activePlayer = GameManager.Instance.ActivePlayer;
+
+        if (activePlayer)
+        {
+            // Add listener to Inventory's OnEquipmentSwitch UnityEvent         
+            activePlayer.inventoryScript.OnEquipmentSwitch?.AddListener(AssignWeaponScript);
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
-        // Update ammo counter text
-        ammoText.text = $"{playerWeaponScript.Ammo} / {playerWeaponScript.startingAmmo}";
+        if (playerWeaponScript)
+        {
+            // Update ammo counter text
+            ammoText.text = playerWeaponScript.Ammo == Mathf.Infinity ? "INF" : $"{playerWeaponScript.Ammo} / {playerWeaponScript.startingAmmo}";
+        }
     }
 
     internal void AssignWeaponScript()
     {
-        // Assign world space event camera
-        playerWeaponScript = GameManager.Instance.ActivePlayer.inventoryScript.currentEquippedItem as WeaponScript;
+        InventoryScript inv = GameManager.Instance.ActivePlayer.inventoryScript;
+
+        // Assign to show currently equipped item
+        playerWeaponScript = inv.GetCurrentEquippedItem() as WeaponScript;
     }
 }

--- a/Assets/Scripts/UI/Screen HUD/HUDAmmoScript.cs.meta
+++ b/Assets/Scripts/UI/Screen HUD/HUDAmmoScript.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 1020
+  executionOrder: 1030
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
- Added several new keybindings in MainPlayerInput for weapon switching.
- Implemented weapon / equipment cycling in InventoryScript using the weapon cycle / wepaon switch keybind.
- Updated equippedItemIndex to be an integer index rather than an IEquipmentItem object. Added GetCurrentEquippedItem() methods to fill in that functionality.
- Added OnEquipmentSwitch event in InventoryScript.
- Updated HUDAmmoScript to add the AssignWeaponScript as a listener to OnEquipmentSwitch event for dynamically updating the displayed ammo count on the HUD based on current equipped item.

== MISC ==
- Some tweaks on ammo text string displayed on the HUD.